### PR TITLE
FIX: Chang the timing about calling logAnalytics.Post

### DIFF
--- a/AzureCost_to_LogAnalytics/AzureCost_to_LogAnalytics/AzureCost_to_LogAnalytics.cs
+++ b/AzureCost_to_LogAnalytics/AzureCost_to_LogAnalytics/AzureCost_to_LogAnalytics.cs
@@ -223,28 +223,23 @@ namespace AzureCost_to_LogAnalytics
                             {
                                 jsonResult += $",{{\"PreTaxCost\": {cost},\"Date\": \"{sDate}\",\"ResourceId\": \"{sResourceId}\",\"ResourceType\": \"{sResourceType}\",\"SubscriptionName\": \"{sSubscriptionName}\",\"ResourceGroup\": \"{sResourceGroup}\"}}";
                             }
-
-
-                            jsonResult += "]";
-
-                            log.LogInformation($"Cost Data: {jsonResult}");
-                            Console.WriteLine($"Cost Data: {jsonResult}");
-                            logAnalytics.Post(jsonResult);
-
-                            string nextLink = result.properties.nextLink.ToString();
-
-                            if (!string.IsNullOrEmpty(nextLink))
-                            {
-                                string skipToken = nextLink.Split('&')[1];
-                                callAPIPage(scope, skipToken, workspaceid, workspacekey, logName, log, myJson);
-                            }
-
-                            //return new OkObjectResult(jsonResult);
                         }
                         catch
                         { }
+                    }
 
+                    jsonResult += "]";
 
+                    log.LogInformation($"Cost Data: {jsonResult}");
+                    Console.WriteLine($"Cost Data: {jsonResult}");
+                    logAnalytics.Post(jsonResult);
+
+                    string nextLink = result.properties.nextLink.ToString();
+
+                    if (!string.IsNullOrEmpty(nextLink))
+                    {
+                        string skipToken = nextLink.Split('&')[1];
+                        callAPIPage(scope, skipToken, workspaceid, workspacekey, logName, log, myJson);
                     }
                 }
             }

--- a/AzureCost_to_LogAnalytics/AzureCost_to_LogAnalytics/PreLoadLogAnalytics.cs
+++ b/AzureCost_to_LogAnalytics/AzureCost_to_LogAnalytics/PreLoadLogAnalytics.cs
@@ -234,34 +234,27 @@ namespace AzureCost_to_LogAnalytics
                             {
                                 jsonResult += $",{{\"PreTaxCost\": {cost},\"Date\": \"{sDate}\",\"ResourceId\": \"{sResourceId}\",\"ResourceType\": \"{sResourceType}\",\"SubscriptionName\": \"{sSubscriptionName}\",\"ResourceGroup\": \"{sResourceGroup}\"}}";
                             }
-
-
-                            jsonResult += "]";
-
-                            log.LogInformation($"Cost Data: {jsonResult}");
-                            Console.WriteLine($"Cost Data: {jsonResult}");
-                            logAnalytics.Post(jsonResult);
-
-                            string nextLink = result.properties.nextLink.ToString();
-
-                            if (!string.IsNullOrEmpty(nextLink))
-                            {
-                                string skipToken = nextLink.Split('&')[1];
-                                callAPIPage(scope, skipToken, workspaceid, workspacekey, logName, log, myJson);
-                            }
-
                             //return new OkObjectResult(jsonResult);
                         }
                         catch
                         { }
-                    
+                    }
+                    jsonResult += "]";
+
+                    log.LogInformation($"Cost Data: {jsonResult}");
+                    Console.WriteLine($"Cost Data: {jsonResult}");
+                    logAnalytics.Post(jsonResult);
+
+                    string nextLink = result.properties.nextLink.ToString();
+
+                    if (!string.IsNullOrEmpty(nextLink))
+                    {
+                        string skipToken = nextLink.Split('&')[1];
+                        callAPIPage(scope, skipToken, workspaceid, workspacekey, logName, log, myJson);
                     }
                 }
-
             }
-                
             return new OkObjectResult(jsonResult);
         }
-        
     }
 }


### PR DESCRIPTION
I want to merge this change because this code posts many requests and the wrong JSON to the logAnalytics. 

Before the code call API each resource. These are some example JSONs posted to the logAnalytics. 

1. first call: [ {\"PreTaxCost\": {cost},\"Date\": \"{sDate}\",\"ResourceId\": \"{sResourceId}\",\"ResourceType\": \"{sResourceType}\",\"SubscriptionName\": \"{sSubscriptionName}\",\"ResourceGroup\": \"{sResourceGroup}\"}]
1. second call: [{\"PreTaxCost\": {cost},\"Date\": \"{sDate}\",\"ResourceId\": \"{sResourceId}\",\"ResourceType\": \"{sResourceType}\",\"SubscriptionName\": \"{sSubscriptionName}\",\"ResourceGroup\": \"{sResourceGroup}\"}]
$",{\"PreTaxCost\": {cost},\"Date\": \"{sDate}\",\"ResourceId\": \"{sResourceId}\",\"ResourceType\": \"{sResourceType}\",\"SubscriptionName\": \"{sSubscriptionName}\",\"ResourceGroup\": \"{sResourceGroup}\"}]
...